### PR TITLE
Fix if statement in shell

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-if [[ -z "$SLACK_BOT_TOKEN" ]]; then
+if test -z "$SLACK_BOT_TOKEN"; then
   echo "Set the SLACK_BOT_TOKEN secret."
   exit 1
 fi


### PR DESCRIPTION
Uses `test` in shell to correctly test the token param. Removes the warning

```bash
/entrypoint.sh: 4: /entrypoint.sh: [[: not found
```