### PR TITLE
Use official curl docker image off alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.6-slim
+FROM curlimages/curl:7.68.0
 
 LABEL "com.github.actions.name"="Post Slack messages"
 LABEL "com.github.actions.description"="Post Slack messages from your own bot"
@@ -9,8 +9,6 @@ LABEL version="1.0.5"
 LABEL repository="http://github.com/pullreminders/slack-action"
 LABEL homepage="http://github.com/pullreminders/slack-action"
 LABEL maintainer="Abi Noda <abi@pullreminders.com>"
-
-RUN apt-get update && apt-get install -y curl
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Replaces the `apt-get install -y curl` with official curl docker image based off of `alpine`. Cuts the build time by more than 50%

![Screen Shot 2020-02-28 at 11 34 50 AM](https://user-images.githubusercontent.com/3671561/75566894-8a0f5200-5a1e-11ea-9b52-78837d7d1b99.png)
![Screen Shot 2020-02-28 at 11 34 28 AM](https://user-images.githubusercontent.com/3671561/75566895-8a0f5200-5a1e-11ea-92b8-126a528c4c61.png)
