### PR TITLE
Support multiline payloads

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ fi
 curl -X POST \
      -H "Content-type: application/json" \
      -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-     -d "$*" \
+     -d \'"$*"\' \
      https://slack.com/api/chat.postMessage


### PR DESCRIPTION
Multiline messages like

    args: |-
      '{
        "channel": "GK32Z5RV1",
        "text": ":docker: image  was built successfully",
      }'

Produce errors from the api 

```{"ok":false,"error":"json_not_object","warning":"missing_charset","response_metadata":{"warnings":["missing_charset"]}}```

Wrapping the payload in `'` removes that error