### PR TITLE
Output the json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,15 @@ if test -z "$SLACK_BOT_TOKEN"; then
   exit 1
 fi
 
-curl -X POST \
+JSON = $(curl -q \
+     -X POST \
      -H "Content-type: application/json" \
      -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
      -d "$*" \
-     https://slack.com/api/chat.postMessage
+     https://slack.com/api/chat.postMessage)
+
+JSON="${JSON//'%'/'%25'}"
+JSON="${JSON//$'\n'/'%0A'}"
+JSON="${JSON//$'\r'/'%0D'}"
+
+echo "::set-output name=response::$JSON"


### PR DESCRIPTION
Slack returns information from its api endpoints. This PR exposes that information in the `response` output parameter for future steps.

This is especially useful for allowing threads since the chat.postMessage api endpoint allows using `thread_ts` to indicate the message is a response to a specific post.